### PR TITLE
extend memoize_zap_cache() to clear all memoized values by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A memoize decorator.
 
 * Install memoize
 ```
-$ pip install git+https://git+https://github.com/ColorGenomics/memoize.git@v0.1.0
+$ pip install git+https://git+https://github.com/ColorGenomics/memoize.git@v0.2.0
 ```
 
 * Use a memoize decorator

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -2,6 +2,9 @@ from decorator import decorator
 import os
 
 
+# functions that have been decorated
+memoize_decorated = set()
+
 def memoize(fun):
     def wrapper(fun, *args, **kwargs):
         if hasattr(fun, '_memoize_keyfunc'):
@@ -21,7 +24,7 @@ def memoize(fun):
 
     decorated = decorator(wrapper, fun)
     memoize_zap_cache(decorated)
-
+    memoize_decorated.add(decorated)
     return decorated
 
 def memoize_per_proc(fun):
@@ -31,8 +34,13 @@ def memoize_per_proc(fun):
 
     return memoize_key(keyfunc)(fun)
 
-def memoize_zap_cache(fun):
-    fun.undecorated._cache = {}
+def memoize_zap_cache(fun=None):
+    """Clear memoized values for all functions (default) or one."""
+    if fun is None:
+        for fun in memoize_decorated:
+            fun.undecorated._cache = {}
+    else:
+        fun.undecorated._cache = {}
 
 memoize_cache = {}
 def memoize_(fun, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except:
 
 
 setup(name = "memoize",
-      version = "0.1.0",
+      version = "0.2.0",
       description = "A memoize decorator",
       author = "Color Genomics",
       author_email = "dev@getcolor.com",


### PR DESCRIPTION
used in snarfed/color@31a17846f9b70d543a4339954b3b03eaa7ad2302
